### PR TITLE
Add Rocket Starwars example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,6 @@ members = [
     "tide/starwars",
     "tide/token-from-header",
     "tide/dataloader",
+
+    "rocket/starwars",
 ]

--- a/rocket/starwars/Cargo.toml
+++ b/rocket/starwars/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rocket-starwars"
+version = "0.1.0"
+authors = ["Daniel Wiesenberg <daniel@simplificAR.io>"]
+edition = "2018"
+
+[dependencies]
+async-graphql = "1.17"
+async-graphql-rocket = "1.17"
+rocket = { git = "https://github.com/SergioBenitez/Rocket/", rev = "dc2c6ec", default-features = false } #TODO: Change to Cargo crate, when Rocket 0.5.0 is released
+starwars = { path = "../../models/starwars" }

--- a/rocket/starwars/Rocket.toml
+++ b/rocket/starwars/Rocket.toml
@@ -1,0 +1,23 @@
+# For more information take a look at https://rocket.rs/guide/configuration/
+[global.limits]
+graphql = 131072
+
+[development]
+address = "localhost"
+port = 8000
+keep_alive = 5
+log = "normal"
+
+
+[staging]
+address = "0.0.0.0"
+port = 8080
+keep_alive = 5
+log = "normal"
+
+
+[production]
+address = "0.0.0.0"
+port = 8080
+keep_alive = 5
+log = "critical"

--- a/rocket/starwars/src/main.rs
+++ b/rocket/starwars/src/main.rs
@@ -1,0 +1,34 @@
+use async_graphql::{EmptyMutation, EmptySubscription, Schema, http::{playground_source, GraphQLPlaygroundConfig}};
+use async_graphql_rocket::{GQLRequest, GraphQL, GQLResponse};
+use rocket::{response::content, routes, State, http::Status};
+use starwars::{QueryRoot, StarWars};
+
+pub type StarWarsSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
+
+#[rocket::get("/")]
+fn graphql_playground() -> content::Html<String> {
+    content::Html(playground_source(GraphQLPlaygroundConfig::new("/")))
+}
+
+#[rocket::post("/?<query..>")]
+async fn graphql_query(schema: State<'_, StarWarsSchema>, query: GQLRequest) -> Result<GQLResponse, Status> {
+    query.execute(&schema)
+        .await
+}
+
+#[rocket::post("/", data = "<request>", format = "application/json")]
+async fn graphql_request(schema: State<'_, StarWarsSchema>, request: GQLRequest) -> Result<GQLResponse, Status> {
+    request.execute(&schema)
+        .await
+}
+
+#[rocket::launch]
+fn rocket() -> rocket::Rocket {
+    let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
+        .data(StarWars::new())
+        .finish();
+
+    rocket::ignite()
+        .attach(GraphQL::fairing(schema))
+        .mount("/", routes![graphql_query, graphql_request, graphql_playground])
+}


### PR DESCRIPTION
Add Rocket Starwars example.

Should i bump the `async-graphql` dependency to version 1.17 in all other examples? Because the Rocket example does not work with the models depending on version 1.16.