### PR TITLE
Update Axum integration to Axum 0.5.1

### DIFF
--- a/axum/starwars/Cargo.toml
+++ b/axum/starwars/Cargo.toml
@@ -9,4 +9,4 @@ async-graphql-axum = { path = "../../../integrations/axum" }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 starwars = { path = "../../models/starwars" }
 hyper = "0.14"
-axum = { version = "0.4", features = ["headers"] }
+axum = { version = "0.5.1", features = ["headers"] }

--- a/axum/subscription/Cargo.toml
+++ b/axum/subscription/Cargo.toml
@@ -9,4 +9,4 @@ async-graphql-axum = { path = "../../../integrations/axum" }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 books = { path = "../../models/books" }
 hyper = "0.14"
-axum = { version = "0.4", features = ["ws", "headers"] }
+axum = { version = "0.5.1", features = ["ws", "headers"] }

--- a/axum/upload/Cargo.toml
+++ b/axum/upload/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 async-graphql = { path = "../../.." }
 async-graphql-axum = { path = "../../../integrations/axum" }
-axum = "0.4"
+axum = "0.5.1"
 files = { path = "../../models/files" }
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 hyper = "0.14"


### PR DESCRIPTION
As requested in https://github.com/async-graphql/async-graphql/pull/883, I've gone ahead and updated the Axum examples from version `0.4` to version `0.5.1`.

Based on my testing, it looks like updating Axum caused no breaking changes for any of the examples.