### PR TITLE
Update Playground to GraphiQL v2

### DIFF
--- a/actix-web/error-extensions/src/main.rs
+++ b/actix-web/error-extensions/src/main.rs
@@ -110,7 +110,7 @@ async fn gql_playgound() -> HttpResponse {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
     HttpServer::new(move || {
         App::new()

--- a/actix-web/error-extensions/src/main.rs
+++ b/actix-web/error-extensions/src/main.rs
@@ -3,9 +3,8 @@ extern crate thiserror;
 
 use actix_web::{guard, web, web::Data, App, HttpResponse, HttpServer};
 use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    EmptyMutation, EmptySubscription, ErrorExtensions, FieldError, FieldResult, Object, ResultExt,
-    Schema,
+    http::GraphiQLSource, EmptyMutation, EmptySubscription, ErrorExtensions, FieldError,
+    FieldResult, Object, ResultExt, Schema,
 };
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
 
@@ -102,7 +101,11 @@ async fn index(
 async fn gql_playgound() -> HttpResponse {
     HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
-        .body(playground_source(GraphQLPlaygroundConfig::new("/")))
+        .body(
+            GraphiQLSource::build()
+                .endpoint("http://localhost:8000")
+                .finish(),
+        )
 }
 
 #[actix_web::main]

--- a/actix-web/starwars/src/main.rs
+++ b/actix-web/starwars/src/main.rs
@@ -7,7 +7,7 @@ async fn index(schema: web::Data<StarWarsSchema>, req: GraphQLRequest) -> GraphQ
     schema.execute(req.into_inner()).await.into()
 }
 
-async fn index_playground() -> Result<HttpResponse> {
+async fn index_graphiql() -> Result<HttpResponse> {
     Ok(HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
         .body(
@@ -23,13 +23,13 @@ async fn main() -> std::io::Result<()> {
         .data(StarWars::new())
         .finish();
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
     HttpServer::new(move || {
         App::new()
             .app_data(Data::new(schema.clone()))
             .service(web::resource("/").guard(guard::Post()).to(index))
-            .service(web::resource("/").guard(guard::Get()).to(index_playground))
+            .service(web::resource("/").guard(guard::Get()).to(index_graphiql))
     })
     .bind("127.0.0.1:8000")?
     .run()

--- a/actix-web/starwars/src/main.rs
+++ b/actix-web/starwars/src/main.rs
@@ -1,8 +1,5 @@
 use actix_web::{guard, web, web::Data, App, HttpResponse, HttpServer, Result};
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    EmptyMutation, EmptySubscription, Schema,
-};
+use async_graphql::{http::GraphiQLSource, EmptyMutation, EmptySubscription, Schema};
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
 use starwars::{QueryRoot, StarWars, StarWarsSchema};
 
@@ -11,10 +8,13 @@ async fn index(schema: web::Data<StarWarsSchema>, req: GraphQLRequest) -> GraphQ
 }
 
 async fn index_playground() -> Result<HttpResponse> {
-    let source = playground_source(GraphQLPlaygroundConfig::new("/").subscription_endpoint("/"));
     Ok(HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
-        .body(source))
+        .body(
+            GraphiQLSource::build()
+                .endpoint("http://localhost:8000")
+                .finish(),
+        ))
 }
 
 #[actix_web::main]

--- a/actix-web/subscription/src/main.rs
+++ b/actix-web/subscription/src/main.rs
@@ -1,8 +1,5 @@
 use actix_web::{guard, web, web::Data, App, HttpRequest, HttpResponse, HttpServer, Result};
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    Schema,
-};
+use async_graphql::{http::GraphiQLSource, Schema};
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
 use books::{BooksSchema, MutationRoot, QueryRoot, Storage, SubscriptionRoot};
 
@@ -13,9 +10,12 @@ async fn index(schema: web::Data<BooksSchema>, req: GraphQLRequest) -> GraphQLRe
 async fn index_playground() -> Result<HttpResponse> {
     Ok(HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
-        .body(playground_source(
-            GraphQLPlaygroundConfig::new("/").subscription_endpoint("/"),
-        )))
+        .body(
+            GraphiQLSource::build()
+                .endpoint("http://localhost:8000")
+                .subscription_endpoint("ws://localhost:8000/ws")
+                .finish(),
+        ))
 }
 
 async fn index_ws(

--- a/actix-web/subscription/src/main.rs
+++ b/actix-web/subscription/src/main.rs
@@ -13,7 +13,7 @@ async fn index_playground() -> Result<HttpResponse> {
         .body(
             GraphiQLSource::build()
                 .endpoint("http://localhost:8000")
-                .subscription_endpoint("ws://localhost:8000/ws")
+                .subscription_endpoint("ws://localhost:8000")
                 .finish(),
         ))
 }

--- a/actix-web/subscription/src/main.rs
+++ b/actix-web/subscription/src/main.rs
@@ -7,7 +7,7 @@ async fn index(schema: web::Data<BooksSchema>, req: GraphQLRequest) -> GraphQLRe
     schema.execute(req.into_inner()).await.into()
 }
 
-async fn index_playground() -> Result<HttpResponse> {
+async fn index_graphiql() -> Result<HttpResponse> {
     Ok(HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
         .body(
@@ -32,7 +32,7 @@ async fn main() -> std::io::Result<()> {
         .data(Storage::default())
         .finish();
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
     HttpServer::new(move || {
         App::new()
@@ -44,7 +44,7 @@ async fn main() -> std::io::Result<()> {
                     .guard(guard::Header("upgrade", "websocket"))
                     .to(index_ws),
             )
-            .service(web::resource("/").guard(guard::Get()).to(index_playground))
+            .service(web::resource("/").guard(guard::Get()).to(index_graphiql))
     })
     .bind("127.0.0.1:8000")?
     .run()

--- a/actix-web/token-from-header/src/main.rs
+++ b/actix-web/token-from-header/src/main.rs
@@ -5,7 +5,7 @@ use async_graphql::{http::GraphiQLSource, Data, EmptyMutation, Schema};
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
 use token::{on_connection_init, QueryRoot, SubscriptionRoot, Token, TokenSchema};
 
-async fn gql_playground() -> HttpResponse {
+async fn graphiql() -> HttpResponse {
     HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
         .body(
@@ -54,12 +54,12 @@ async fn index_ws(
 async fn main() -> std::io::Result<()> {
     let schema = Schema::new(QueryRoot, EmptyMutation, SubscriptionRoot);
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
     HttpServer::new(move || {
         App::new()
             .app_data(web::Data::new(schema.clone()))
-            .service(web::resource("/").guard(guard::Get()).to(gql_playground))
+            .service(web::resource("/").guard(guard::Get()).to(graphiql))
             .service(web::resource("/").guard(guard::Post()).to(index))
             .service(web::resource("/ws").to(index_ws))
     })

--- a/actix-web/token-from-header/src/main.rs
+++ b/actix-web/token-from-header/src/main.rs
@@ -1,19 +1,19 @@
 use actix_web::{
     guard, http::header::HeaderMap, web, App, HttpRequest, HttpResponse, HttpServer, Result,
 };
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    Data, EmptyMutation, Schema,
-};
+use async_graphql::{http::GraphiQLSource, Data, EmptyMutation, Schema};
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
 use token::{on_connection_init, QueryRoot, SubscriptionRoot, Token, TokenSchema};
 
 async fn gql_playground() -> HttpResponse {
     HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
-        .body(playground_source(
-            GraphQLPlaygroundConfig::new("/").subscription_endpoint("/ws"),
-        ))
+        .body(
+            GraphiQLSource::build()
+                .endpoint("http://localhost:8000")
+                .subscription_endpoint("ws://localhost:8000/ws")
+                .finish(),
+        )
 }
 
 fn get_token_from_headers(headers: &HeaderMap) -> Option<Token> {

--- a/actix-web/upload/src/main.rs
+++ b/actix-web/upload/src/main.rs
@@ -1,6 +1,6 @@
 use actix_web::{guard, web, web::Data, App, HttpResponse, HttpServer};
 use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig, MultipartOptions},
+    http::{GraphiQLSource, MultipartOptions},
     EmptySubscription, Schema,
 };
 use async_graphql_actix_web::{GraphQLRequest, GraphQLResponse};
@@ -13,7 +13,11 @@ async fn index(schema: web::Data<FilesSchema>, req: GraphQLRequest) -> GraphQLRe
 async fn gql_playgound() -> HttpResponse {
     HttpResponse::Ok()
         .content_type("text/html; charset=utf-8")
-        .body(playground_source(GraphQLPlaygroundConfig::new("/")))
+        .body(
+            GraphiQLSource::build()
+                .endpoint("http://localhost:8000")
+                .finish(),
+        )
 }
 
 #[actix_web::main]

--- a/actix-web/upload/src/main.rs
+++ b/actix-web/upload/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> std::io::Result<()> {
         .data(Storage::default())
         .finish();
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
     HttpServer::new(move || {
         App::new()

--- a/axum/starwars/src/main.rs
+++ b/axum/starwars/src/main.rs
@@ -15,7 +15,7 @@ async fn graphql_handler(
     schema.execute(req.into_inner()).await.into()
 }
 
-async fn graphql_playground() -> impl IntoResponse {
+async fn graphiql() -> impl IntoResponse {
     response::Html(
         GraphiQLSource::build()
             .endpoint("http://localhost:8000")
@@ -30,10 +30,10 @@ async fn main() {
         .finish();
 
     let app = Router::new()
-        .route("/", get(graphql_playground).post(graphql_handler))
+        .route("/", get(graphiql).post(graphql_handler))
         .layer(Extension(schema));
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
     Server::bind(&"0.0.0.0:8000".parse().unwrap())
         .serve(app.into_make_service())

--- a/axum/starwars/src/main.rs
+++ b/axum/starwars/src/main.rs
@@ -1,7 +1,4 @@
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    EmptyMutation, EmptySubscription, Schema,
-};
+use async_graphql::{http::GraphiQLSource, EmptyMutation, EmptySubscription, Schema};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{
     extract::Extension,
@@ -19,7 +16,11 @@ async fn graphql_handler(
 }
 
 async fn graphql_playground() -> impl IntoResponse {
-    response::Html(playground_source(GraphQLPlaygroundConfig::new("/")))
+    response::Html(
+        GraphiQLSource::build()
+            .endpoint("http://localhost:8000")
+            .finish(),
+    )
 }
 
 #[tokio::main]

--- a/axum/subscription/src/main.rs
+++ b/axum/subscription/src/main.rs
@@ -1,7 +1,4 @@
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    Schema,
-};
+use async_graphql::{http::GraphiQLSource, Schema};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
 use axum::{
     extract::Extension,
@@ -16,9 +13,12 @@ async fn graphql_handler(schema: Extension<BooksSchema>, req: GraphQLRequest) ->
 }
 
 async fn graphql_playground() -> impl IntoResponse {
-    response::Html(playground_source(
-        GraphQLPlaygroundConfig::new("/").subscription_endpoint("/ws"),
-    ))
+    response::Html(
+        GraphiQLSource::build()
+            .endpoint("http://localhost:8000")
+            .subscription_endpoint("ws://localhost:8000/ws")
+            .finish(),
+    )
 }
 
 #[tokio::main]

--- a/axum/subscription/src/main.rs
+++ b/axum/subscription/src/main.rs
@@ -12,7 +12,7 @@ async fn graphql_handler(schema: Extension<BooksSchema>, req: GraphQLRequest) ->
     schema.execute(req.into_inner()).await.into()
 }
 
-async fn graphql_playground() -> impl IntoResponse {
+async fn graphiql() -> impl IntoResponse {
     response::Html(
         GraphiQLSource::build()
             .endpoint("http://localhost:8000")
@@ -28,11 +28,11 @@ async fn main() {
         .finish();
 
     let app = Router::new()
-        .route("/", get(graphql_playground).post(graphql_handler))
+        .route("/", get(graphiql).post(graphql_handler))
         .route("/ws", GraphQLSubscription::new(schema.clone()))
         .layer(Extension(schema));
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
     Server::bind(&"0.0.0.0:8000".parse().unwrap())
         .serve(app.into_make_service())

--- a/axum/upload/src/main.rs
+++ b/axum/upload/src/main.rs
@@ -1,7 +1,4 @@
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    EmptySubscription, Schema,
-};
+use async_graphql::{http::GraphiQLSource, EmptySubscription, Schema};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{
     extract::Extension,
@@ -18,7 +15,11 @@ async fn graphql_handler(schema: Extension<FilesSchema>, req: GraphQLRequest) ->
 }
 
 async fn graphql_playground() -> impl IntoResponse {
-    Html(playground_source(GraphQLPlaygroundConfig::new("/")))
+    Html(
+        GraphiQLSource::build()
+            .endpoint("http://localhost:8000")
+            .finish(),
+    )
 }
 
 #[tokio::main]

--- a/axum/upload/src/main.rs
+++ b/axum/upload/src/main.rs
@@ -14,7 +14,7 @@ async fn graphql_handler(schema: Extension<FilesSchema>, req: GraphQLRequest) ->
     schema.execute(req.0).await.into()
 }
 
-async fn graphql_playground() -> impl IntoResponse {
+async fn graphiql() -> impl IntoResponse {
     Html(
         GraphiQLSource::build()
             .endpoint("http://localhost:8000")
@@ -28,10 +28,10 @@ async fn main() {
         .data(Storage::default())
         .finish();
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
     let app = Router::new()
-        .route("/", get(graphql_playground).post(graphql_handler))
+        .route("/", get(graphiql).post(graphql_handler))
         .layer(Extension(schema))
         .layer(
             CorsLayer::new()

--- a/poem/starwars/src/main.rs
+++ b/poem/starwars/src/main.rs
@@ -4,7 +4,7 @@ use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, 
 use starwars::{QueryRoot, StarWars};
 
 #[handler]
-async fn graphql_playground() -> impl IntoResponse {
+async fn graphiql() -> impl IntoResponse {
     Html(
         GraphiQLSource::build()
             .endpoint("http://localhost:8000")
@@ -18,9 +18,9 @@ async fn main() {
         .data(StarWars::new())
         .finish();
 
-    let app = Route::new().at("/", get(graphql_playground).post(GraphQL::new(schema)));
+    let app = Route::new().at("/", get(graphiql).post(GraphQL::new(schema)));
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
     Server::new(TcpListener::bind("0.0.0.0:8000"))
         .run(app)
         .await

--- a/poem/starwars/src/main.rs
+++ b/poem/starwars/src/main.rs
@@ -1,14 +1,15 @@
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    EmptyMutation, EmptySubscription, Schema,
-};
+use async_graphql::{http::GraphiQLSource, EmptyMutation, EmptySubscription, Schema};
 use async_graphql_poem::GraphQL;
 use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
 use starwars::{QueryRoot, StarWars};
 
 #[handler]
 async fn graphql_playground() -> impl IntoResponse {
-    Html(playground_source(GraphQLPlaygroundConfig::new("/")))
+    Html(
+        GraphiQLSource::build()
+            .endpoint("http://localhost:8000")
+            .finish(),
+    )
 }
 
 #[tokio::main]

--- a/poem/subscription-redis/src/main.rs
+++ b/poem/subscription-redis/src/main.rs
@@ -40,7 +40,7 @@ impl SubscriptionRoot {
 }
 
 #[handler]
-async fn graphql_playground() -> impl IntoResponse {
+async fn graphiql() -> impl IntoResponse {
     Html(
         GraphiQLSource::build()
             .endpoint("http://localhost:8000")
@@ -58,13 +58,10 @@ async fn main() {
         .finish();
 
     let app = Route::new()
-        .at(
-            "/",
-            get(graphql_playground).post(GraphQL::new(schema.clone())),
-        )
+        .at("/", get(graphiql).post(GraphQL::new(schema.clone())))
         .at("/ws", get(GraphQLSubscription::new(schema)));
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
     Server::new(TcpListener::bind("0.0.0.0:8000"))
         .run(app)
         .await

--- a/poem/subscription-redis/src/main.rs
+++ b/poem/subscription-redis/src/main.rs
@@ -1,7 +1,4 @@
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    Context, Object, Result, Schema, Subscription,
-};
+use async_graphql::{http::GraphiQLSource, Context, Object, Result, Schema, Subscription};
 use async_graphql_poem::{GraphQL, GraphQLSubscription};
 use futures_util::{Stream, StreamExt};
 use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
@@ -44,9 +41,12 @@ impl SubscriptionRoot {
 
 #[handler]
 async fn graphql_playground() -> impl IntoResponse {
-    Html(playground_source(
-        GraphQLPlaygroundConfig::new("/").subscription_endpoint("/ws"),
-    ))
+    Html(
+        GraphiQLSource::build()
+            .endpoint("http://localhost:8000")
+            .subscription_endpoint("ws://localhost:8000/ws")
+            .finish(),
+    )
 }
 
 #[tokio::main]

--- a/poem/subscription/src/main.rs
+++ b/poem/subscription/src/main.rs
@@ -4,7 +4,7 @@ use books::{MutationRoot, QueryRoot, Storage, SubscriptionRoot};
 use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
 
 #[handler]
-async fn graphql_playground() -> impl IntoResponse {
+async fn graphiql() -> impl IntoResponse {
     Html(
         GraphiQLSource::build()
             .endpoint("http://localhost:8000")
@@ -20,13 +20,10 @@ async fn main() {
         .finish();
 
     let app = Route::new()
-        .at(
-            "/",
-            get(graphql_playground).post(GraphQL::new(schema.clone())),
-        )
+        .at("/", get(graphiql).post(GraphQL::new(schema.clone())))
         .at("/ws", get(GraphQLSubscription::new(schema)));
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
     Server::new(TcpListener::bind("0.0.0.0:8000"))
         .run(app)
         .await

--- a/poem/subscription/src/main.rs
+++ b/poem/subscription/src/main.rs
@@ -1,16 +1,16 @@
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    Schema,
-};
+use async_graphql::{http::GraphiQLSource, Schema};
 use async_graphql_poem::{GraphQL, GraphQLSubscription};
 use books::{MutationRoot, QueryRoot, Storage, SubscriptionRoot};
 use poem::{get, handler, listener::TcpListener, web::Html, IntoResponse, Route, Server};
 
 #[handler]
 async fn graphql_playground() -> impl IntoResponse {
-    Html(playground_source(
-        GraphQLPlaygroundConfig::new("/").subscription_endpoint("/ws"),
-    ))
+    Html(
+        GraphiQLSource::build()
+            .endpoint("http://localhost:8000")
+            .subscription_endpoint("ws://localhost:8000/ws")
+            .finish(),
+    )
 }
 
 #[tokio::main]

--- a/poem/token-from-header/src/main.rs
+++ b/poem/token-from-header/src/main.rs
@@ -19,7 +19,7 @@ fn get_token_from_headers(headers: &HeaderMap) -> Option<Token> {
 }
 
 #[handler]
-async fn graphql_playground() -> impl IntoResponse {
+async fn graphiql() -> impl IntoResponse {
     Html(
         GraphiQLSource::build()
             .endpoint("http://localhost:8000")
@@ -69,11 +69,11 @@ async fn main() {
     let schema = Schema::new(QueryRoot, EmptyMutation, SubscriptionRoot);
 
     let app = Route::new()
-        .at("/", get(graphql_playground).post(index))
+        .at("/", get(graphiql).post(index))
         .at("/ws", get(ws))
         .data(schema);
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
     Server::new(TcpListener::bind("0.0.0.0:8000"))
         .run(app)
         .await

--- a/poem/token-from-header/src/main.rs
+++ b/poem/token-from-header/src/main.rs
@@ -1,5 +1,5 @@
 use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig, ALL_WEBSOCKET_PROTOCOLS},
+    http::{GraphiQLSource, ALL_WEBSOCKET_PROTOCOLS},
     EmptyMutation, Schema,
 };
 use async_graphql_poem::{GraphQLProtocol, GraphQLRequest, GraphQLResponse, GraphQLWebSocket};
@@ -20,9 +20,12 @@ fn get_token_from_headers(headers: &HeaderMap) -> Option<Token> {
 
 #[handler]
 async fn graphql_playground() -> impl IntoResponse {
-    Html(playground_source(
-        GraphQLPlaygroundConfig::new("/").subscription_endpoint("/ws"),
-    ))
+    Html(
+        GraphiQLSource::build()
+            .endpoint("http://localhost:8000")
+            .subscription_endpoint("ws://localhost:8000/ws")
+            .finish(),
+    )
 }
 
 #[handler]

--- a/poem/upload/src/main.rs
+++ b/poem/upload/src/main.rs
@@ -15,7 +15,7 @@ async fn index(schema: Data<&FilesSchema>, req: GraphQLRequest) -> GraphQLRespon
 }
 
 #[handler]
-async fn gql_playground() -> impl IntoResponse {
+async fn graphiql() -> impl IntoResponse {
     Html(
         GraphiQLSource::build()
             .endpoint("http://localhost:8000")
@@ -29,10 +29,10 @@ async fn main() -> std::io::Result<()> {
         .data(Storage::default())
         .finish();
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
     let app = Route::new()
-        .at("/", get(gql_playground).post(index))
+        .at("/", get(graphiql).post(index))
         .with(Cors::new())
         .data(schema);
     Server::new(TcpListener::bind("0.0.0.0:8000"))

--- a/poem/upload/src/main.rs
+++ b/poem/upload/src/main.rs
@@ -1,7 +1,4 @@
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    EmptySubscription, Schema,
-};
+use async_graphql::{http::GraphiQLSource, EmptySubscription, Schema};
 use async_graphql_poem::{GraphQLRequest, GraphQLResponse};
 use files::{FilesSchema, MutationRoot, QueryRoot, Storage};
 use poem::{
@@ -19,7 +16,11 @@ async fn index(schema: Data<&FilesSchema>, req: GraphQLRequest) -> GraphQLRespon
 
 #[handler]
 async fn gql_playground() -> impl IntoResponse {
-    Html(playground_source(GraphQLPlaygroundConfig::new("/")))
+    Html(
+        GraphiQLSource::build()
+            .endpoint("http://localhost:8000")
+            .finish(),
+    )
 }
 
 #[tokio::main]

--- a/rocket/starwars/src/main.rs
+++ b/rocket/starwars/src/main.rs
@@ -1,7 +1,4 @@
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    EmptyMutation, EmptySubscription, Schema,
-};
+use async_graphql::{http::GraphiQLSource, EmptyMutation, EmptySubscription, Schema};
 use async_graphql_rocket::{GraphQLQuery, GraphQLRequest, GraphQLResponse};
 use rocket::{response::content, routes, State};
 use starwars::{QueryRoot, StarWars};
@@ -10,7 +7,7 @@ pub type StarWarsSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
 
 #[rocket::get("/")]
 fn graphql_playground() -> content::RawHtml<String> {
-    content::RawHtml(playground_source(GraphQLPlaygroundConfig::new("/graphql")))
+    content::RawHtml(GraphiQLSource::build().endpoint("/graphql").finish())
 }
 
 #[rocket::get("/graphql?<query..>")]

--- a/rocket/starwars/src/main.rs
+++ b/rocket/starwars/src/main.rs
@@ -6,7 +6,7 @@ use starwars::{QueryRoot, StarWars};
 pub type StarWarsSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
 
 #[rocket::get("/")]
-fn graphql_playground() -> content::RawHtml<String> {
+fn graphiql() -> content::RawHtml<String> {
     content::RawHtml(GraphiQLSource::build().endpoint("/graphql").finish())
 }
 
@@ -29,8 +29,7 @@ fn rocket() -> _ {
         .data(StarWars::new())
         .finish();
 
-    rocket::build().manage(schema).mount(
-        "/",
-        routes![graphql_query, graphql_request, graphql_playground],
-    )
+    rocket::build()
+        .manage(schema)
+        .mount("/", routes![graphql_query, graphql_request, graphiql])
 }

--- a/rocket/upload/src/main.rs
+++ b/rocket/upload/src/main.rs
@@ -6,7 +6,7 @@ use rocket::{response::content, routes, State};
 pub type StarWarsSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
 
 #[rocket::get("/")]
-fn graphql_playground() -> content::RawHtml<String> {
+fn graphiql() -> content::RawHtml<String> {
     content::RawHtml(GraphiQLSource::build().endpoint("/graphql").finish())
 }
 
@@ -45,7 +45,7 @@ fn rocket() -> _ {
             graphql_query,
             graphql_request,
             graphql_request_multipart,
-            graphql_playground
+            graphiql
         ],
     )
 }

--- a/rocket/upload/src/main.rs
+++ b/rocket/upload/src/main.rs
@@ -1,7 +1,4 @@
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    EmptyMutation, EmptySubscription, Schema,
-};
+use async_graphql::{http::GraphiQLSource, EmptyMutation, EmptySubscription, Schema};
 use async_graphql_rocket::{GraphQLQuery, GraphQLRequest, GraphQLResponse};
 use files::{FilesSchema, MutationRoot, QueryRoot, Storage};
 use rocket::{response::content, routes, State};
@@ -10,7 +7,7 @@ pub type StarWarsSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
 
 #[rocket::get("/")]
 fn graphql_playground() -> content::RawHtml<String> {
-    content::RawHtml(playground_source(GraphQLPlaygroundConfig::new("/graphql")))
+    content::RawHtml(GraphiQLSource::build().endpoint("/graphql").finish())
 }
 
 #[rocket::get("/graphql?<query..>")]

--- a/tide/dataloader-postgres/src/main.rs
+++ b/tide/dataloader-postgres/src/main.rs
@@ -114,7 +114,7 @@ async fn run() -> Result<()> {
         Ok(resp)
     });
 
-    println!("Playground: http://127.0.0.1:8000");
+    println!("GraphiQL IDE: http://127.0.0.1:8000");
     app.listen("127.0.0.1:8000").await?;
 
     Ok(())

--- a/tide/dataloader-postgres/src/main.rs
+++ b/tide/dataloader-postgres/src/main.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, env};
 use async_graphql::{
     dataloader::{DataLoader, Loader},
     futures_util::TryStreamExt,
-    http::{playground_source, GraphQLPlaygroundConfig},
+    http::GraphiQLSource,
     Context, EmptyMutation, EmptySubscription, FieldError, Object, Result, Schema, SimpleObject,
 };
 use async_std::task;
@@ -105,9 +105,11 @@ async fn run() -> Result<()> {
     app.at("/graphql").post(async_graphql_tide::graphql(schema));
     app.at("/").get(|_| async move {
         let mut resp = Response::new(StatusCode::Ok);
-        resp.set_body(Body::from_string(playground_source(
-            GraphQLPlaygroundConfig::new("/graphql"),
-        )));
+        resp.set_body(Body::from_string(
+            GraphiQLSource::build()
+                .endpoint("http://localhost:8000/graphql")
+                .finish(),
+        ));
         resp.set_content_type(mime::HTML);
         Ok(resp)
     });

--- a/tide/dataloader/src/main.rs
+++ b/tide/dataloader/src/main.rs
@@ -113,7 +113,7 @@ async fn run() -> Result<()> {
         Ok(resp)
     });
 
-    println!("Playground: http://127.0.0.1:8000");
+    println!("GraphiQL IDE: http://127.0.0.1:8000");
     app.listen("127.0.0.1:8000").await?;
 
     Ok(())

--- a/tide/dataloader/src/main.rs
+++ b/tide/dataloader/src/main.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use async_graphql::{
     dataloader::{DataLoader, Loader},
     futures_util::TryStreamExt,
-    http::{playground_source, GraphQLPlaygroundConfig},
+    http::GraphiQLSource,
     Context, EmptyMutation, EmptySubscription, FieldError, Object, Result, Schema, SimpleObject,
 };
 use async_std::task;
@@ -104,9 +104,11 @@ async fn run() -> Result<()> {
     app.at("/graphql").post(async_graphql_tide::graphql(schema));
     app.at("/").get(|_| async move {
         let mut resp = Response::new(StatusCode::Ok);
-        resp.set_body(Body::from_string(playground_source(
-            GraphQLPlaygroundConfig::new("/graphql"),
-        )));
+        resp.set_body(Body::from_string(
+            GraphiQLSource::build()
+                .endpoint("http://localhost:8000/graphql")
+                .finish(),
+        ));
         resp.set_content_type(mime::HTML);
         Ok(resp)
     });

--- a/tide/starwars/src/main.rs
+++ b/tide/starwars/src/main.rs
@@ -1,9 +1,6 @@
 use std::env;
 
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    EmptyMutation, EmptySubscription, Schema,
-};
+use async_graphql::{http::GraphiQLSource, EmptyMutation, EmptySubscription, Schema};
 use async_std::task;
 use starwars::{QueryRoot, StarWars};
 use tide::{http::mime, Body, Response, StatusCode};
@@ -29,9 +26,9 @@ async fn run() -> Result<()> {
 
     app.at("/").get(|_| async move {
         let mut resp = Response::new(StatusCode::Ok);
-        resp.set_body(Body::from_string(playground_source(
-            GraphQLPlaygroundConfig::new("/graphql"),
-        )));
+        resp.set_body(Body::from_string(
+            GraphiQLSource::build().endpoint("/graphql").finish(),
+        ));
         resp.set_content_type(mime::HTML);
         Ok(resp)
     });

--- a/tide/starwars/src/main.rs
+++ b/tide/starwars/src/main.rs
@@ -18,7 +18,7 @@ async fn run() -> Result<()> {
         .data(StarWars::new())
         .finish();
 
-    println!("Playground: http://{}", listen_addr);
+    println!("GraphiQL IDE: http://{}", listen_addr);
 
     let mut app = tide::new();
 

--- a/tide/subscription/src/main.rs
+++ b/tide/subscription/src/main.rs
@@ -14,7 +14,7 @@ async fn run() -> Result<()> {
         .data(Storage::default())
         .finish();
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
     let mut app = tide::new();
 

--- a/warp/starwars/src/main.rs
+++ b/warp/starwars/src/main.rs
@@ -12,7 +12,7 @@ async fn main() {
         .data(StarWars::new())
         .finish();
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
     let graphql_post = async_graphql_warp::graphql(schema).and_then(
         |(schema, request): (
@@ -23,7 +23,7 @@ async fn main() {
         },
     );
 
-    let graphql_playground = warp::path::end().and(warp::get()).map(|| {
+    let graphiql = warp::path::end().and(warp::get()).map(|| {
         HttpResponse::builder()
             .header("content-type", "text/html")
             .body(
@@ -33,7 +33,7 @@ async fn main() {
             )
     });
 
-    let routes = graphql_playground
+    let routes = graphiql
         .or(graphql_post)
         .recover(|err: Rejection| async move {
             if let Some(GraphQLBadRequest(err)) = err.find() {

--- a/warp/starwars/src/main.rs
+++ b/warp/starwars/src/main.rs
@@ -1,9 +1,6 @@
 use std::convert::Infallible;
 
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    EmptyMutation, EmptySubscription, Schema,
-};
+use async_graphql::{http::GraphiQLSource, EmptyMutation, EmptySubscription, Schema};
 use async_graphql_warp::{GraphQLBadRequest, GraphQLResponse};
 use http::StatusCode;
 use starwars::{QueryRoot, StarWars};
@@ -29,7 +26,11 @@ async fn main() {
     let graphql_playground = warp::path::end().and(warp::get()).map(|| {
         HttpResponse::builder()
             .header("content-type", "text/html")
-            .body(playground_source(GraphQLPlaygroundConfig::new("/")))
+            .body(
+                GraphiQLSource::build()
+                    .endpoint("http://localhost:8000")
+                    .finish(),
+            )
     });
 
     let routes = graphql_playground

--- a/warp/subscription/src/main.rs
+++ b/warp/subscription/src/main.rs
@@ -1,9 +1,6 @@
 use std::convert::Infallible;
 
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    Schema,
-};
+use async_graphql::{http::GraphiQLSource, Schema};
 use async_graphql_warp::{graphql_subscription, GraphQLResponse};
 use books::{MutationRoot, QueryRoot, Storage, SubscriptionRoot};
 use warp::{http::Response as HttpResponse, Filter};
@@ -28,9 +25,12 @@ async fn main() {
     let graphql_playground = warp::path::end().and(warp::get()).map(|| {
         HttpResponse::builder()
             .header("content-type", "text/html")
-            .body(playground_source(
-                GraphQLPlaygroundConfig::new("/").subscription_endpoint("/"),
-            ))
+            .body(
+                GraphiQLSource::build()
+                    .endpoint("http://localhost:8000")
+                    .subscription_endpoint("ws://localhost:8000")
+                    .finish(),
+            )
     });
 
     let routes = graphql_subscription(schema)

--- a/warp/subscription/src/main.rs
+++ b/warp/subscription/src/main.rs
@@ -11,7 +11,7 @@ async fn main() {
         .data(Storage::default())
         .finish();
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
     let graphql_post = async_graphql_warp::graphql(schema.clone()).and_then(
         |(schema, request): (
@@ -22,7 +22,7 @@ async fn main() {
         },
     );
 
-    let graphql_playground = warp::path::end().and(warp::get()).map(|| {
+    let graphiql = warp::path::end().and(warp::get()).map(|| {
         HttpResponse::builder()
             .header("content-type", "text/html")
             .body(
@@ -33,8 +33,6 @@ async fn main() {
             )
     });
 
-    let routes = graphql_subscription(schema)
-        .or(graphql_playground)
-        .or(graphql_post);
+    let routes = graphql_subscription(schema).or(graphiql).or(graphql_post);
     warp::serve(routes).run(([0, 0, 0, 0], 8000)).await;
 }

--- a/warp/token-from-header/src/main.rs
+++ b/warp/token-from-header/src/main.rs
@@ -1,9 +1,6 @@
 use std::convert::Infallible;
 
-use async_graphql::{
-    http::{playground_source, GraphQLPlaygroundConfig},
-    Data, EmptyMutation, Schema,
-};
+use async_graphql::{http::GraphiQLSource, Data, EmptyMutation, Schema};
 use async_graphql_warp::{graphql_protocol, GraphQLResponse, GraphQLWebSocket};
 use token::{on_connection_init, QueryRoot, SubscriptionRoot, Token};
 use warp::{http::Response as HttpResponse, ws::Ws, Filter};
@@ -17,9 +14,12 @@ async fn main() {
     let graphql_playground = warp::path::end().and(warp::get()).map(|| {
         HttpResponse::builder()
             .header("content-type", "text/html")
-            .body(playground_source(
-                GraphQLPlaygroundConfig::new("/").subscription_endpoint("/ws"),
-            ))
+            .body(
+                GraphiQLSource::build()
+                    .endpoint("http://localhost:8000")
+                    .subscription_endpoint("ws://localhost:8000/ws")
+                    .finish(),
+            )
     });
 
     let graphql_post = warp::header::optional::<String>("token")

--- a/warp/token-from-header/src/main.rs
+++ b/warp/token-from-header/src/main.rs
@@ -9,9 +9,9 @@ use warp::{http::Response as HttpResponse, ws::Ws, Filter};
 async fn main() {
     let schema = Schema::build(QueryRoot, EmptyMutation, SubscriptionRoot).finish();
 
-    println!("Playground: http://localhost:8000");
+    println!("GraphiQL IDE: http://localhost:8000");
 
-    let graphql_playground = warp::path::end().and(warp::get()).map(|| {
+    let graphiql = warp::path::end().and(warp::get()).map(|| {
         HttpResponse::builder()
             .header("content-type", "text/html")
             .body(
@@ -68,6 +68,6 @@ async fn main() {
             },
         );
 
-    let routes = subscription.or(graphql_playground).or(graphql_post);
+    let routes = subscription.or(graphiql).or(graphql_post);
     warp::serve(routes).run(([0, 0, 0, 0], 8000)).await;
 }


### PR DESCRIPTION
This PR updates the examples to include the new GraphiQL IDE (see https://github.com/async-graphql/async-graphql/pull/1044).

GraphiQL requires that the passed `subscriptionUrl` is a valid websocket url. Therefore, we cannot use a relative path (`/ws` for example), since that uses the http (`http://`) protocol instead of the websocket one (`ws://`). I therefore included the full url in almost every example to be consistent. 

_In the rocket example I did not, because this example does not use websockets and the url is different for various environments (see `Rocket.toml`). The same is the case for one of the tide examples which includes some test that involves an environment variable. I removed that environment variable from the tide example that did not include tests._