### PR TITLE
(poem) remove token from header in ws endpoint

### DIFF
--- a/models/token/src/lib.rs
+++ b/models/token/src/lib.rs
@@ -33,6 +33,8 @@ pub async fn on_connection_init(value: serde_json::Value) -> Result<Data> {
         token: String,
     }
 
+    // Coerce the connection params into our `Payload` struct so we can
+    // validate the token exists in the headers.
     if let Ok(payload) = serde_json::from_value::<Payload>(value) {
         let mut data = Data::default();
         data.insert(Token(payload.token));

--- a/models/token/src/lib.rs
+++ b/models/token/src/lib.rs
@@ -27,6 +27,8 @@ impl SubscriptionRoot {
     }
 }
 
+// For more details see:
+// https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#connectioninit
 pub async fn on_connection_init(value: serde_json::Value) -> Result<Data> {
     #[derive(Deserialize)]
     struct Payload {

--- a/poem/token-from-header/src/main.rs
+++ b/poem/token-from-header/src/main.rs
@@ -48,17 +48,11 @@ async fn ws(
     protocol: GraphQLProtocol,
     websocket: WebSocket,
 ) -> impl IntoResponse {
-    let mut data = async_graphql::Data::default();
-    if let Some(token) = get_token_from_headers(headers) {
-        data.insert(token);
-    }
-
     let schema = schema.0.clone();
     websocket
         .protocols(ALL_WEBSOCKET_PROTOCOLS)
         .on_upgrade(move |stream| {
             GraphQLWebSocket::new(stream, schema, protocol)
-                .with_data(data)
                 .on_connection_init(on_connection_init)
                 .serve()
         })

--- a/poem/token-from-header/src/main.rs
+++ b/poem/token-from-header/src/main.rs
@@ -53,6 +53,7 @@ async fn ws(
         .protocols(ALL_WEBSOCKET_PROTOCOLS)
         .on_upgrade(move |stream| {
             GraphQLWebSocket::new(stream, schema, protocol)
+                // connection params are used to extract the token in this fn
                 .on_connection_init(on_connection_init)
                 .serve()
         })


### PR DESCRIPTION
RE: https://github.com/async-graphql/async-graphql/issues/1075

Removes the code to extract token from header in the poem token_from_header example's `ws` endpoint