### PR TITLE
Tweak some sqlx syntax to be more idiomatic

### DIFF
--- a/tide/dataloader-postgres/Cargo.toml
+++ b/tide/dataloader-postgres/Cargo.toml
@@ -10,7 +10,7 @@ async-graphql-tide = { path = "../../../integrations/tide" }
 async-std = "1.9.0"
 async-trait = "0.1.42"
 itertools = "0.10.0"
-sqlx = { version = "0.5.5", features = ["runtime-async-std-rustls", "postgres"] }
+sqlx = { version = "0.6.2", features = ["runtime-async-std-rustls", "postgres"] }
 tide = "0.16.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Specifically, use `.bind()` instead of `format!()` as best practice (even though SQL injection in this specific case is not a concern) and use the shorter `PgPool` alias.