### PR TITLE
fix: use correct start scripts for federations

### DIFF
--- a/federation/dynamic-schema/start.sh
+++ b/federation/dynamic-schema/start.sh
@@ -11,17 +11,17 @@ function cleanup {
 }
 trap cleanup EXIT
 
-cargo build --bin static-federation-accounts
-cargo build --bin static-federation-products
-cargo build --bin static-federation-reviews
+cargo build --bin dynamic-federation-accounts
+cargo build --bin dynamic-federation-products
+cargo build --bin dynamic-federation-reviews
 
-cargo run --bin static-federation-accounts &
+cargo run --bin dynamic-federation-accounts &
 ACCOUNTS_PID=$!
 
-cargo run --bin static-federation-products &
+cargo run --bin dynamic-federation-products &
 PRODUCTS_PID=$!
 
-cargo run --bin static-federation-reviews &
+cargo run --bin dynamic-federation-reviews &
 REVIEWS_PID=$!
 
 sleep 3

--- a/federation/dynamic-schema/start.sh
+++ b/federation/dynamic-schema/start.sh
@@ -3,11 +3,10 @@
 set -eumo pipefail
 
 function cleanup {
-  kill "$PRODUCTS_ROVER_PID"
-  kill "$REVIEWS_ROVER_PID"
-    kill "$ACCOUNTS_PID"
-    kill "$PRODUCTS_PID"
-    kill "$REVIEWS_PID"
+  for pid in "${PRODUCTS_ROVER_PID:-}" "${REVIEWS_ROVER_PID:-}" "${ACCOUNTS_PID:-}" "${PRODUCTS_PID:-}" "${REVIEWS_PID:-}"; do
+    # try kill all registered pids
+    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && kill "$pid" || echo "Could not kill $pid"
+  done
 }
 trap cleanup EXIT
 

--- a/federation/static-schema/start.sh
+++ b/federation/static-schema/start.sh
@@ -11,17 +11,17 @@ function cleanup {
 }
 trap cleanup EXIT
 
-cargo build --bin dynamic-federation-accounts
-cargo build --bin dynamic-federation-products
-cargo build --bin dynamic-federation-reviews
+cargo build --bin static-federation-accounts
+cargo build --bin static-federation-products
+cargo build --bin static-federation-reviews
 
-cargo run --bin dynamic-federation-accounts &
+cargo run --bin static-federation-accounts &
 ACCOUNTS_PID=$!
 
-cargo run --bin dynamic-federation-products &
+cargo run --bin static-federation-products &
 PRODUCTS_PID=$!
 
-cargo run --bin dynamic-federation-reviews &
+cargo run --bin static-federation-reviews &
 REVIEWS_PID=$!
 
 sleep 3

--- a/federation/static-schema/start.sh
+++ b/federation/static-schema/start.sh
@@ -3,11 +3,10 @@
 set -eumo pipefail
 
 function cleanup {
-  kill "$PRODUCTS_ROVER_PID"
-  kill "$REVIEWS_ROVER_PID"
-    kill "$ACCOUNTS_PID"
-    kill "$PRODUCTS_PID"
-    kill "$REVIEWS_PID"
+  for pid in "${PRODUCTS_ROVER_PID:-}" "${REVIEWS_ROVER_PID:-}" "${ACCOUNTS_PID:-}" "${PRODUCTS_PID:-}" "${REVIEWS_PID:-}"; do
+    # try kill all registered pids
+    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && kill "$pid" || echo "Could not kill $pid"
+  done
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
1. The start.sh scripts is now in correct folder
2. cleanup functions try kill all PIDs (it didn't worked if one of process exited on it's own - for example when address was in use). 